### PR TITLE
Add ATTOM Property Snapshot example

### DIFF
--- a/attom_snapshot.py
+++ b/attom_snapshot.py
@@ -1,0 +1,26 @@
+import requests
+import json
+
+API_KEY = "d72597eea0ed245a73b9bea2a69f7bc0"
+ENDPOINT = "https://api.gateway.attomdata.com/propertyapi/v1.0.0/property/snapshot"
+
+params = {
+    "postalcode": "93611",
+    "propertytype": "SFR"  # Single Family Residential
+}
+
+headers = {
+    "accept": "application/json",
+    "apikey": API_KEY
+}
+
+response = requests.get(ENDPOINT, params=params, headers=headers)
+
+try:
+    response.raise_for_status()
+    data = response.json()
+    print(json.dumps(data, indent=2))
+except requests.HTTPError as e:
+    print(f"HTTP error: {e}")
+    print(response.text)
+


### PR DESCRIPTION
## Summary
- add `attom_snapshot.py` script to call the ATTOM Property Snapshot API

## Testing
- `pytest -q`
- `python3 attom_snapshot.py` *(fails: ProxyError 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840fc5622b08333881f9b438bd40c8c